### PR TITLE
fix: snapaligner index generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#77](https://github.com/nf-core/references/pull/77) - Fix createsequencedictionary usage
 - [#81](https://github.com/nf-core/references/pull/81) - Fix fasta_fai unnecessary regeneration
 - [#90](https://github.com/nf-core/references/pull/90) - Fixed link to GHA CI broken by [87](https://github.com/nf-core/references/pull/87)
+- [#141](https://github.com/nf-core/references/pull/141) - Fix snapaligner index generation when no alt liftover file is provided
 
 ### Dependencies
 

--- a/main.nf
+++ b/main.nf
@@ -123,7 +123,7 @@ workflow NFCORE_REFERENCES {
     // Mix the references that were extracted with the references that did not need to be extracted
     // Some references are not extracted because they are usually not stored in an archived format
     // TODO: check if more references need to be extracted
-    altliftoverfile = channel.empty()
+    altliftoverfile = false
 
     REFERENCES(
         altliftoverfile,

--- a/subworkflows/local/prepare_genome_dnaseq/main.nf
+++ b/subworkflows/local/prepare_genome_dnaseq/main.nf
@@ -46,9 +46,11 @@ workflow PREPARE_GENOME_DNASEQ {
         "vcf",
     )
 
-    SNAPALIGNER_INDEX(
-        fasta.combine(altliftoverfile).map { meta, fasta_, altliftoverfile_ -> [meta, fasta_, [], [], altliftoverfile_] }.filter { meta, _snap_input -> 'snapaligner' in tools && meta.run_snapaligner }
-    )
+    def fasta_for_snapaligner = altliftoverfile
+        ? fasta.combine(altliftoverfile).map { meta, fasta_, altliftoverfile_ -> [meta, fasta_, [], [], altliftoverfile_] }
+        : fasta.map { meta, fasta_ -> [meta, fasta_, [], [], []] }
+
+    SNAPALIGNER_INDEX(fasta_for_snapaligner.filter { meta, _fasta, _altcontigfile, _nonaltcontigfile, _altliftoverfile -> 'snapaligner' in tools && meta.run_snapaligner })
 
     emit:
     bwamem1_index     = BWAMEM1_INDEX.out.index // channel: [meta, BWAmemIndex/]

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -12,6 +12,8 @@
 **/dragmap/*/hash_table.cfg.bin
 **/dragmap/*/hash_table_stats.txt
 **/kallisto
+**/snap/GenomeIndexHash
+**/snap/OverflowTable
 .DS_Store
 index.json
 multiqc/multiqc_data/llms-full.txt

--- a/tests/snapaligner.nf.test
+++ b/tests/snapaligner.nf.test
@@ -1,0 +1,40 @@
+nextflow_pipeline {
+
+    name "Build snapaligner references"
+    script "../main.nf"
+    tag "pipeline"
+
+    test("-profile test --tools snapaligner") {
+
+        options "-output-dir ${outputDir}"
+
+        when {
+            params {
+                outdir       = "${outputDir}"
+                tools        = 'snapaligner'
+                tools_bundle = null
+                skip_tools   = null
+            }
+        }
+
+        then {
+            // stable_path: All files + folders in ${params.outdir}/ with a stable path (including file name)
+            def stable_path = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            // stable_content: All files in ${params.outdir}/ with stable content
+            def stable_content = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assert workflow.success
+            assertAll(
+                { assert snapshot(
+                    // Number of successful tasks
+                    workflow.trace.succeeded().size(),
+                    // pipeline versions.yml file for multiqc from which Nextflow and pipeline versions are removed (all from the workflow key)
+                    removeFromYamlMap("${outputDir}/pipeline_info/nf_core_references_software_mqc_versions.yml", 'Workflow'),
+                    // All stable path name, with a relative path
+                    stable_path,
+                    // All files with stable contents
+                    stable_content
+                ).match() }
+            )
+        }
+    }
+}

--- a/tests/snapaligner.nf.test.snap
+++ b/tests/snapaligner.nf.test.snap
@@ -33,12 +33,10 @@
             [
                 "Genome:md5,366047c9112c837914ce255c16833480",
                 "GenomeIndex:md5,baeedbd4a4534c9a065740335bbe6318",
-                "GenomeIndexHash:md5,27009b947703bd27a3c8b7a0308e944e",
-                "OverflowTable:md5,4e25d70d2f3d3013fa2323398858f07c",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-06-11T12:48:21.143744205",
+        "timestamp": "2026-06-11T13:07:25.327994814",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.3"

--- a/tests/snapaligner.nf.test.snap
+++ b/tests/snapaligner.nf.test.snap
@@ -1,0 +1,47 @@
+{
+    "-profile test --tools snapaligner": {
+        "content": [
+            2,
+            {
+                "SNAPALIGNER_INDEX": {
+                    "snap-aligner": "2.0.5"
+                }
+            },
+            [
+                "Homo_sapiens",
+                "Homo_sapiens/nf-core",
+                "Homo_sapiens/nf-core/GRCh38_chr21",
+                "Homo_sapiens/nf-core/GRCh38_chr21/snap",
+                "Homo_sapiens/nf-core/GRCh38_chr21/snap/Genome",
+                "Homo_sapiens/nf-core/GRCh38_chr21/snap/GenomeIndex",
+                "Homo_sapiens/nf-core/GRCh38_chr21/snap/GenomeIndexHash",
+                "Homo_sapiens/nf-core/GRCh38_chr21/snap/OverflowTable",
+                "index.json",
+                "multiqc",
+                "multiqc/multiqc_data",
+                "multiqc/multiqc_data/llms-full.txt",
+                "multiqc/multiqc_data/multiqc.log",
+                "multiqc/multiqc_data/multiqc.parquet",
+                "multiqc/multiqc_data/multiqc_citations.txt",
+                "multiqc/multiqc_data/multiqc_data.json",
+                "multiqc/multiqc_data/multiqc_software_versions.txt",
+                "multiqc/multiqc_data/multiqc_sources.txt",
+                "multiqc/multiqc_report.html",
+                "pipeline_info",
+                "pipeline_info/nf_core_references_software_mqc_versions.yml"
+            ],
+            [
+                "Genome:md5,366047c9112c837914ce255c16833480",
+                "GenomeIndex:md5,baeedbd4a4534c9a065740335bbe6318",
+                "GenomeIndexHash:md5,27009b947703bd27a3c8b7a0308e944e",
+                "OverflowTable:md5,4e25d70d2f3d3013fa2323398858f07c",
+                "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
+            ]
+        ],
+        "timestamp": "2026-06-11T12:48:21.143744205",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}

--- a/workflows/references.nf
+++ b/workflows/references.nf
@@ -57,6 +57,7 @@ workflow REFERENCES {
     msisensorpro_list = PREPARE_GENOME_DNASEQ.out.msisensorpro_list
     rsem_index = PREPARE_GENOME_RNASEQ.out.rsem_index
     salmon_index = PREPARE_GENOME_RNASEQ.out.salmon_index
+    snapaligner_index = PREPARE_GENOME_DNASEQ.out.snapaligner_index
     splice_sites = PREPARE_GENOME_RNASEQ.out.splice_sites
     star_index = PREPARE_GENOME_RNASEQ.out.star_index
     transcript_fasta = PREPARE_GENOME_RNASEQ.out.transcript_fasta
@@ -89,6 +90,7 @@ workflow REFERENCES {
             msisensorpro_list.map { meta, reference_ -> [meta + [file: 'msisensorpro_list'], reference_] },
             rsem_index.map { meta, reference_ -> [meta + [file: 'rsem_index'], reference_] },
             salmon_index.map { meta, reference_ -> [meta + [file: 'salmon_index'], reference_] },
+            snapaligner_index.map { meta, reference_ -> [meta + [file: 'snapaligner_index'], reference_] },
             splice_sites.map { meta, reference_ -> [meta + [file: 'splice_sites'], reference_] },
             star_index.map { meta, reference_ -> [meta + [file: 'star_index'], reference_] },
             transcript_fasta.map { meta, reference_ -> [meta + [file: 'transcript_fasta'], reference_] },


### PR DESCRIPTION
Fix snapaligner index generation when no alt liftover file is provided.

Changes:
- Changed `altliftoverfile` from `channel.empty()` to `false` for simpler handling
- Updated SNAPALIGNER_INDEX to handle both cases (with/without altliftoverfile)
- Added missing `snapaligner_index` output in references.nf
- Added snapaligner test and snapshot