### PR TITLE
Add NCBI_API_KEY to env scope in nextflow.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#139](https://github.com/nf-core/references/pull/139) - Added NCBI_API_KEY support to avoid rate limiting on NCBI Datasets API
 - [#140](https://github.com/nf-core/references/pull/140) - Added `tools_bundle` and `skip_tools` parameters for pre-defined tool bundles (`all`, `rnaseq`, `sarek`)
 - [#142](https://github.com/nf-core/references/pull/142) - Add `AGENTS.md` file with nf-core agent instructions
+- Added NCBI_API_KEY to env scope in nextflow.config
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#139](https://github.com/nf-core/references/pull/139) - Added NCBI_API_KEY support to avoid rate limiting on NCBI Datasets API
 - [#140](https://github.com/nf-core/references/pull/140) - Added `tools_bundle` and `skip_tools` parameters for pre-defined tool bundles (`all`, `rnaseq`, `sarek`)
 - [#142](https://github.com/nf-core/references/pull/142) - Add `AGENTS.md` file with nf-core agent instructions
-- Added NCBI_API_KEY to env scope in nextflow.config
+- [#145](https://github.com/nf-core/references/pull/145) - Added NCBI_API_KEY to env scope in nextflow.config
 
 ### Changed
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -203,6 +203,7 @@ env {
     R_PROFILE_USER   = "/.Rprofile"
     R_ENVIRON_USER   = "/.Renviron"
     JULIA_DEPOT_PATH = "/usr/local/share/julia"
+    NCBI_API_KEY     = "${System.getenv('NCBI_API_KEY') ?: ''}"
 }
 
 // Set bash options


### PR DESCRIPTION
Add NCBI_API_KEY to the env scope in nextflow.config to make it explicit that the pipeline supports NCBI API key for avoiding rate limiting. This follows the same pattern as other environment variables like PYTHONNOUSERSITE.

The NCBI_API_KEY is already used in conf/modules.config via `System.getenv('NCBI_API_KEY')`, but adding it to the env scope makes the support explicit and ensures it's available to all processes.

Generated via opencode
Verified by @maxulysse