### PR TITLE
Fix params access and add contributing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#143](https://github.com/nf-core/references/pull/143) - Update modules
 - [#146](https://github.com/nf-core/references/pull/146) - Convert meta maps to Nextflow record types
 - [#147](https://github.com/nf-core/references/pull/147) - Template update for nf-core/tools v4.1.0
-- [#149](https://github.com/nf-core/references/pull/149) - Enable static typing and fix params access
 
 ### Removed
 
@@ -64,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#81](https://github.com/nf-core/references/pull/81) - Fix fasta_fai unnecessary regeneration
 - [#90](https://github.com/nf-core/references/pull/90) - Fixed link to GHA CI broken by [87](https://github.com/nf-core/references/pull/87)
 - [#141](https://github.com/nf-core/references/pull/141) - Fix snapaligner index generation when no alt liftover file is provided
+- [#149](https://github.com/nf-core/references/pull/149) - Fix params access
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#143](https://github.com/nf-core/references/pull/143) - Update modules
 - [#146](https://github.com/nf-core/references/pull/146) - Convert meta maps to Nextflow record types
 - [#147](https://github.com/nf-core/references/pull/147) - Template update for nf-core/tools v4.1.0
+- [#149](https://github.com/nf-core/references/pull/149) - Enable static typing and fix params access
 
 ### Removed
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -182,4 +182,27 @@ If you update images or graphics, follow the nf-core [style guidelines](https://
 
 ## Pipeline specific contribution guidelines
 
-<!-- TODO nf-core: Add any pipeline specific contribution guidelines here, such as coding styles, procedures, checklists etc. -->
+### Record types
+
+This pipeline uses Nextflow record types instead of meta maps.
+
+- Use `record()` to create records with named fields
+- Access record fields by name (e.g. `meta.id`, `meta.fasta`)
+- Use `reduceMeta()` to create records from input datasheet rows
+- Do not use tuple syntax `[meta, file]` for new code
+
+For migration guidance, see the [Nextflow agent skill on migrating Nextflow code](https://github.com/nextflow-io/agent-skills/blob/master/skills/migrate-nextflow-code/SKILL.md).
+
+### Workflow outputs
+
+This pipeline uses the Nextflow `output {}` block in `main.nf` to publish files.
+Each output type has its own path declaration using the `file >>` syntax.
+
+Output paths follow this structure:
+
+```text
+${meta.species}/${meta.source}/${meta.genome}/Sequence/<tool>/<version>/
+${meta.species}/${meta.source}/${meta.genome}/Annotation/<type>/
+```
+
+When adding a new output, add a corresponding entry to the `output {}` block in `main.nf`.

--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,5 @@
 #!/usr/bin/env nextflow
+nextflow.enable.types = true
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     nf-core/references
@@ -38,8 +39,8 @@ include { paramsSummaryMap         } from 'plugin/nf-schema'
 // WORKFLOW: Build references depending on type of reference and the tools specified
 workflow NFCORE_REFERENCES {
     take:
-    references
-    tools // list of tools to use to build references
+    references: Channel
+    tools: List
 
     main:
 

--- a/main.nf
+++ b/main.nf
@@ -297,11 +297,12 @@ workflow {
     def collated_versions = softwareVersionsToYAML(
         softwareVersions: channel.topic("versions"),
         nextflowVersion: workflow.nextflow.version,
-    ).collect().map { versions ->
-        def file = file("${params.outdir}/pipeline_info/nf_core_references_software_mqc_versions.yml")
-        file.text = versions.join('\n')
-        file
-    }
+    ).collectFile(
+        storeDir: "${params.outdir}/pipeline_info",
+        name: 'nf_core_' + 'references_software_' + 'mqc_' + 'versions.yml',
+        sort: true,
+        newLine: true,
+    )
 
     // MULTIQC
     def multiqc_files = channel.empty()
@@ -314,16 +315,8 @@ workflow {
     def multiqc_custom_methods_description = params.multiqc_methods_description ? file(params.multiqc_methods_description, checkIfExists: true) : file("${projectDir}/assets/methods_description_template.yml", checkIfExists: true)
     def methods_description = channel.value(methodsDescriptionText(multiqc_custom_methods_description))
 
-    multiqc_files = multiqc_files.mix(workflow_summary.collect().map { summary ->
-        def file = file("${params.outdir}/pipeline_info/workflow_summary_mqc.yaml")
-        file.text = summary.join('\n')
-        file
-    })
-    multiqc_files = multiqc_files.mix(methods_description.collect().map { methods ->
-        def file = file("${params.outdir}/pipeline_info/methods_description_mqc.yaml")
-        file.text = methods.join('\n')
-        file
-    })
+    multiqc_files = multiqc_files.mix(workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
+    multiqc_files = multiqc_files.mix(methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true))
 
     MULTIQC(
         multiqc_files.flatten().collect().map { files ->

--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,4 @@
 #!/usr/bin/env nextflow
-nextflow.enable.types = true
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     nf-core/references
@@ -39,8 +38,8 @@ include { paramsSummaryMap         } from 'plugin/nf-schema'
 // WORKFLOW: Build references depending on type of reference and the tools specified
 workflow NFCORE_REFERENCES {
     take:
-    references: Channel
-    tools: List
+    references
+    tools
 
     main:
 

--- a/main.nf
+++ b/main.nf
@@ -297,12 +297,11 @@ workflow {
     def collated_versions = softwareVersionsToYAML(
         softwareVersions: channel.topic("versions"),
         nextflowVersion: workflow.nextflow.version,
-    ).collectFile(
-        storeDir: "${params.outdir}/pipeline_info",
-        name: 'nf_core_' + 'references_software_' + 'mqc_' + 'versions.yml',
-        sort: true,
-        newLine: true,
-    )
+    ).collect().map { versions ->
+        def file = file("${params.outdir}/pipeline_info/nf_core_references_software_mqc_versions.yml")
+        file.text = versions.join('\n')
+        file
+    }
 
     // MULTIQC
     def multiqc_files = channel.empty()
@@ -315,8 +314,16 @@ workflow {
     def multiqc_custom_methods_description = params.multiqc_methods_description ? file(params.multiqc_methods_description, checkIfExists: true) : file("${projectDir}/assets/methods_description_template.yml", checkIfExists: true)
     def methods_description = channel.value(methodsDescriptionText(multiqc_custom_methods_description))
 
-    multiqc_files = multiqc_files.mix(workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-    multiqc_files = multiqc_files.mix(methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true))
+    multiqc_files = multiqc_files.mix(workflow_summary.collect().map { summary ->
+        def file = file("${params.outdir}/pipeline_info/workflow_summary_mqc.yaml")
+        file.text = summary.join('\n')
+        file
+    })
+    multiqc_files = multiqc_files.mix(methods_description.collect().map { methods ->
+        def file = file("${params.outdir}/pipeline_info/methods_description_mqc.yaml")
+        file.text = methods.join('\n')
+        file
+    })
 
     MULTIQC(
         multiqc_files.flatten().collect().map { files ->

--- a/main.nf
+++ b/main.nf
@@ -39,7 +39,7 @@ include { paramsSummaryMap         } from 'plugin/nf-schema'
 workflow NFCORE_REFERENCES {
     take:
     references
-    tools
+    tools // list of tools to use to build references
 
     main:
 

--- a/subworkflows/local/utils_nfcore_references_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_references_pipeline/main.nf
@@ -105,7 +105,7 @@ workflow PIPELINE_INITIALISATION {
         log.info(
             paramsHelp(
                 help_options,
-                params.help instanceof String ? params.help : "",
+                help instanceof String ? help : "",
             )
         )
         exit(0)


### PR DESCRIPTION
## Changes

- Fix `params.help` access in `PIPELINE_INITIALISATION` to use the `help` parameter from `take:`
- Add record types and workflow outputs sections to `docs/CONTRIBUTING.md`

Generated by opencode
Verified by @maxulysse 